### PR TITLE
adding guidance for 'wget: command not found'

### DIFF
--- a/download_data.sh
+++ b/download_data.sh
@@ -1,3 +1,18 @@
+# checking if wget is installed on a computer
+if ! command -v wget &> /dev/null
+then
+    echo ""
+    echo "wget command could not be found on your computer. Please, install it first."
+    echo "If you cannot/dontwantto install wget, you may try to download the features manually."
+    echo "You may find the links and correct paths in this file."
+    echo "Make sure to check the md5 sums after manual download:"
+    echo "./data/i3d_25fps_stack64step64_2stream_npy.zip    d7266e440f8c616acbc0d8aaa4a336dc"
+    echo "./data/vggish_npy.zip    9a654ad785e801aceb70af2a5e1cffbe"
+    echo "./.vector_cache/glove.840B.300d.zip    2ffafcc9f9ae46fc8c95f32372976137"
+    exit
+fi
+
+
 echo "Downloading i3d features"
 cd data/
 wget https://a3s.fi/swift/v1/AUTH_a235c0f452d648828f745589cde1219a/bmt/i3d_25fps_stack64step64_2stream_npy.zip -q --show-progress

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,6 +1,7 @@
 # checking if wget is installed on a computer
 if ! command -v wget &> /dev/null
 then
+    echo "wget: command not found"
     echo ""
     echo "wget command could not be found on your computer. Please, install it first."
     echo "If you cannot/dontwantto install wget, you may try to download the features manually."


### PR DESCRIPTION
Ok. I cannot believe I am doing this but it seems like a problem for many wanderers (at least: #10, #3, and in comments to this [Medium post](https://towardsdatascience.com/dense-video-captioning-using-pytorch-392ca0d6971a). 

When a computer doesn't have `wget`, the `bash ./data_download.sh` will complain about it. However, it might not be enough to guess that `wget` is missing on the system and gives a false belief that the download/extraction actually succeeded.

By this PR, I am adding an explicit error message to `./data_download.sh` advising what to do:

```
❯ bash download_data.sh
wget: command not found

wget command could not be found on your computer. Please, install it first.
If you cannot/dontwantto install wget, you may try to download the features manually.
You may find the links and correct paths in this file.
Make sure to check the md5 sums after manual download:
./data/i3d_25fps_stack64step64_2stream_npy.zip    d7266e440f8c616acbc0d8aaa4a336dc
./data/vggish_npy.zip    9a654ad785e801aceb70af2a5e1cffbe
./.vector_cache/glove.840B.300d.zip    2ffafcc9f9ae46fc8c95f32372976137
```

